### PR TITLE
Removes Imagemin.pngquant call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,6 @@ function minify (options, files, file, done) {
     .src(files[file].contents)
     .use(Imagemin.jpegtran(options))
     .use(Imagemin.gifsicle(options))
-    .use(Imagemin.pngquant(options))
     .use(Imagemin.optipng(options))
     .use(Imagemin.svgo({ plugins: options.svgoPlugins || [] }))
 


### PR DESCRIPTION
Since Imagemin version 3.2, [imagemin-pngquant is not bundled with imagemin anymore](https://github.com/imagemin/imagemin/commit/1762d328fd7fc83369cacb431445a6e693b6eae6). As a result, the plugin fails because of the call to `Imagemin.pngquant`.
